### PR TITLE
style: formatting for readability

### DIFF
--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -4,7 +4,7 @@ export function formatDescription(data: DocsData, c: string | undefined) {
   if (typeof c !== 'string') {
     return '';
   }
-  return formatTokens(data, tokenize(c));  
+  return formatTokens(data, tokenize(c));
 }
 
 export function formatType(data: DocsData, c: string | undefined) {
@@ -28,7 +28,7 @@ export function formatType(data: DocsData, c: string | undefined) {
 
   // If the type has more than three alternates, format into separate lines
   if (types.length > 3) {
-    formatted = "| " + types.join("<br>| ");
+    formatted = "|&nbsp;" + types.join("<br>|&nbsp;");
   }
 
   return {
@@ -47,7 +47,7 @@ function formatTokens(data: DocsData, tokens: string[]) {
       f += '&lt;';
       continue;
     }
-    
+
     if (t === '>') {
       f += '&gt;';
       continue;

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -22,16 +22,19 @@ export function formatType(data: DocsData, c: string | undefined) {
     }
   }
 
-  const rtn = {
-    type: tokens.join(''),
-    formatted: formatTokens(data, tokens),
-  };
+  const type = tokens.join('');
+  let formatted = formatTokens(data, tokens);
+  const types = formatted.split(/ \| /);
 
-  if (rtn.formatted.length > 0) {
-    rtn.formatted = `<code>${rtn.formatted}</code>`;
+  // If the type has more than three alternates, format into separate lines
+  if (types.length > 3) {
+    formatted = "| " + types.join("<br>| ");
   }
 
-  return rtn;
+  return {
+    type,
+    formatted,
+  };
 }
 
 function formatTokens(data: DocsData, tokens: string[]) {

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -103,7 +103,7 @@ const createBorder = (th: RowData) => {
 
   th.columns.forEach(c => {
     const borderCol: ColumnData = {
-      text: '',
+      text: ':',
       width: c.width,
     };
     while (borderCol.text.length < borderCol.width) {

--- a/src/output.ts
+++ b/src/output.ts
@@ -90,16 +90,24 @@ function replaceMarkdownDocsApi(content: string, data: DocsData) {
 function markdownIndex(data: DocsData) {
   const o: string[] = [];
 
+  if (data?.api?.methods.length) {
+    o.push(`**Methods**`)
+  }
+
   data?.api?.methods.forEach(m => {
-    o.push(`* [\`${m.name}(${m.parameters.length > 0 ? '...' : ''})\`](#${m.slug})`);
+    o.push(`[${m.name}(${m.parameters.length > 0 ? '...' : ''})](#${m.slug})`);
   });
 
+  if (data?.api?.methods.length) {
+    o.push(`\n`);
+  }
+
   if (data.interfaces.length > 0) {
-    o.push(`* [Interfaces](#interfaces)`);
+    o.push(`[Interfaces](#interfaces)`);
   }
 
   if (data.enums.length > 0) {
-    o.push(`* [Enums](#enums)`);
+    o.push(`[Enums](#enums)`);
   }
 
   return o.join('\n').trim();
@@ -120,7 +128,11 @@ function markdownApi(data: DocsData) {
   if (data.interfaces.length > 0) {
     o.push(`### Interfaces`);
     o.push(``);
-    data.interfaces.forEach(i => {
+    data.interfaces.forEach((i, index) => {
+      if (index > 0) {
+        o.push(`<br>`);
+      }
+
       o.push(interfaceTable(data, i));
     });
     o.push(``);
@@ -183,7 +195,7 @@ function createMethodParamTable(data: DocsData, parameters: DocsMethodParam[]) {
   t.addHeader([`Param`, `Type`, `Description`]);
 
   parameters.forEach(p => {
-    const nm = `**\`${p.name}\`**`;
+    const nm = `${p.name}`;
     const ty = formatType(data, p.type);
     const docs = formatDescription(data, p.docs);
     t.addRow([nm, ty.formatted, docs]);
@@ -213,10 +225,10 @@ function interfaceTable(data: DocsData, i: DocsInterface) {
       const defaultValue = getTagText(m.tags, 'default');
 
       t.addRow([
-        `**\`${m.name}\`**`,
+        `${m.name}`,
         formatType(data, m.type).formatted,
         formatDescription(data, m.docs),
-        defaultValue ? `<code>${defaultValue}</code>` : '',
+        defaultValue ? `${defaultValue}` : '',
         getTagText(m.tags, 'since'),
       ]);
     });
@@ -233,7 +245,7 @@ function interfaceTable(data: DocsData, i: DocsInterface) {
 
     i.methods.forEach(m => {
       t.addRow([
-        `**${m.name}**`,
+        `${m.name}`,
         formatDescription(data, m.signature),
         formatDescription(data, m.docs)
       ]);
@@ -260,7 +272,7 @@ function enumTable(data: DocsData, i: DocsEnum) {
 
     i.members.forEach(m => {
       t.addRow([
-        `**\`${m.name}\`**`,
+        `${m.name}`,
         formatType(data, m.value).formatted,
         formatDescription(data, m.docs),
         getTagText(m.tags, 'since'),


### PR DESCRIPTION
- Left align column headers.
- Remove code styling.
- Remove bold in most places.
- Add vertical white space between tables.
- Split alternate type value lists > 3 into separate lines.
- Don’t put index into `<li>`.
- Separate methods in index.

### Motivation

I have 30 years experience in typography, graphic design and readability that guided these changes.

I removed the code styles (except for fenced code blocks) for a few reasons:

- Code style is really meant to distinguish a span of text within a larger context, for example like `this`. In the case of docgen, every chunk of code is either on its own line or within a table cell.
- In the case of table cells, styling as code adds a box around the text. So there is a box within a box, which is much harder for the eye to parse.
- Monospaced fonts are more difficult to read in the context of mixed typography. Using a proportional font aids readability.

I added more vertical space between tables to make it easier for the eye to pick out the beginning of the table.

If a type has more than three alternates, it is split up into multiple lines, which greatly improves readability. For example, instead of this:

| Prop | Type | Details |
| :---- | :---- | :------- |
| iosImageDisplayMode | "top" \| "center" \| "bottom" \| "fill" \| "aspectFill" \| "fit" \| "left" \| "right" \| "topLeft" \| "topRight" \| "bottomLeft" \| "bottomRight" | The mode used to place and scale an image splash screen. Ignored for storyboard-based splash screens. |

you get this:

| Prop | Type | Details |
| :---- | :---- | :------- |
| iosImageDisplayMode | \|&nbsp;"top"<br>\|&nbsp;"center"<br>\|&nbsp;"bottom"<br>\|&nbsp;"fill"<br>\|&nbsp;"aspectFill"<br>\|&nbsp;"fit"<br>\|&nbsp;"left"<br>\|&nbsp;"right"<br>\|&nbsp;"topLeft"<br>\|&nbsp;"topRight"<br>\|&nbsp;"bottomLeft"<br>\|&nbsp;"bottomRight" | The mode used to place and scale an image splash screen. Ignored for storyboard-based splash screens. |
