### PR TITLE
feat(method): change to be able to add extends object

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -45,7 +45,18 @@ export function parse(opts: DocsParseOptions) {
   });
 
   return (api: string) => {
-    const apiInterface = interfaces.find(i => i.name === api) || null;
+    let apiInterface = interfaces.find(i => i.name === api) || null;
+    const allImportObject = interfaces
+      .filter(i => apiInterface?.importObject.includes(i.name) && i.name !== api)
+      .map(i => i.importObject);
+
+    const otherMethod = interfaces
+      .filter(i => [...new Set(allImportObject.flat())].includes(i.name))
+      .map(d => d.methods)|| null;
+
+    if (apiInterface !== null && otherMethod && otherMethod.length > 0) {
+      apiInterface.methods = [...new Set(apiInterface?.methods.concat(otherMethod.flat(1)))];
+    }
 
     const data: DocsData = {
       api: apiInterface,
@@ -173,6 +184,9 @@ function getInterface(
   const symbol = typeChecker.getSymbolAtLocation(node.name);
   const docs = symbol ? serializeSymbol(typeChecker, symbol) : null;
 
+  // @ts-ignore
+  const importObject = node.parent?.locals?.keys() || null
+
   const i: DocsInterface = {
     name: interfaceName,
     slug: slugify(interfaceName),
@@ -180,6 +194,7 @@ function getInterface(
     tags: docs?.tags || [],
     methods,
     properties,
+    importObject: [...importObject]
   };
 
   return i;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -185,7 +185,7 @@ function getInterface(
   const docs = symbol ? serializeSymbol(typeChecker, symbol) : null;
 
   // @ts-ignore
-  const importObject = node.parent?.locals?.keys() || null
+  const importObject = node.parent?.locals?.keys() || []
 
   const i: DocsInterface = {
     name: interfaceName,

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface DocsInterface {
   tags: DocsTagInfo[];
   methods: DocsInterfaceMethod[];
   properties: DocsInterfaceProperty[];
+  importObject: string[];
 }
 
 export interface DocsEnum {


### PR DESCRIPTION
Added support for extends from other file. For example:

```ts
import type { BannerDefinitions } from './banner';
import type { InterstitialDefinitions } from './interstitial';
import type { RewardDefinitions } from './reward';

type AdMobDefinitions = BannerDefinitions &
  RewardDefinitions &
  InterstitialDefinitions;

export interface AdMobPlugin extends AdMobDefinitions {
  initialize(options: AdMobInitializationOptions): Promise<void>;
}
```

fix: https://github.com/ionic-team/capacitor-docgen/issues/22