### PR TITLE
feat(method): change to be able to add extends object

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -46,6 +46,10 @@ export function parse(opts: DocsParseOptions) {
 
   return (api: string) => {
     let apiInterface = interfaces.find(i => i.name === api) || null;
+
+    /**
+     * Add methods of import(many is used in `extends`)
+     */
     const allImportObject = interfaces
       .filter(i => apiInterface?.importObject.includes(i.name) && i.name !== api)
       .map(i => i.importObject);
@@ -194,7 +198,7 @@ function getInterface(
     tags: docs?.tags || [],
     methods,
     properties,
-    importObject: [...importObject]
+    importObject: [...importObject].filter((d: string) => d !== interfaceName)
   };
 
   return i;

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface DocsInterface {
   tags: DocsTagInfo[];
   methods: DocsInterfaceMethod[];
   properties: DocsInterfaceProperty[];
+  importObject: string[];
 }
 
 export interface DocsEnum {


### PR DESCRIPTION
Added support for extends from other file. For example:

```ts
import type { BannerDefinitions } from './banner';
import type { InterstitialDefinitions } from './interstitial';
import type { RewardDefinitions } from './reward';

type AdMobDefinitions = BannerDefinitions &
  RewardDefinitions &
  InterstitialDefinitions;

export interface AdMobPlugin extends AdMobDefinitions {
  initialize(options: AdMobInitializationOptions): Promise<void>;
}
```

fix: https://github.com/ionic-team/capacitor-docgen/issues/22