### PR TITLE
fix: export in module style

### DIFF
--- a/src/output.ts
+++ b/src/output.ts
@@ -275,7 +275,7 @@ function buildExamples(c: DocsConfigInterface) {
   o.push(`  },`);
   o.push(`};`);
   o.push(``);
-  o.push(`export = config;`);
+  o.push(`export default config;`);
   o.push(`\`\`\``);
 
   return o.join('\n');

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -251,7 +251,7 @@ const config: CapacitorConfig = {
   },
 };
 
-export = config;
+export default config;
 ```
 
 </docgen-config>


### PR DESCRIPTION
The `capacitor.config.ts` file created by the CLI uses `export default config;` instead of `export = config;`. Was changed because it didn't play well with angular and we decided it should be documented as the recommended way, but somehow I forgot when created the automatic config generation.
