### PR TITLE
chore: Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,25 +9,25 @@
       "version": "0.0.16",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^14.14.31",
+        "@types/node": "^14.17.3",
         "colorette": "^1.2.2",
         "github-slugger": "^1.3.0",
         "minimist": "^1.2.5",
-        "typescript": "^4.2.2"
+        "typescript": "~4.2.4"
       },
       "bin": {
         "docgen": "bin/docgen"
       },
       "devDependencies": {
-        "@capacitor/cli": "^3.0.0-beta.3",
-        "@ionic/prettier-config": "^1.0.0",
-        "@stencil/core": "^2.4.0",
+        "@capacitor/cli": "^3.0.1",
+        "@ionic/prettier-config": "^1.0.1",
+        "@stencil/core": "^2.6.0",
         "@types/github-slugger": "^1.3.0",
-        "@types/jest": "^26.0.20",
+        "@types/jest": "^26.0.23",
         "@types/minimist": "^1.2.1",
         "jest": "^26.6.3",
-        "np": "^7.4.0",
-        "prettier": "^2.2.1",
+        "np": "^7.5.0",
+        "prettier": "^2.3.1",
         "rimraf": "^3.0.2"
       },
       "engines": {
@@ -454,9 +454,9 @@
       "dev": true
     },
     "node_modules/@capacitor/cli": {
-      "version": "3.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-3.0.0-beta.4.tgz",
-      "integrity": "sha512-gZQZxTvobxRzRdasPmMie0PhvnZ/Phc11jiUYpjyUdhJMxz0CrKpTnQ2bH/yuwfGpGHYKDhXhq4FXZEwevKWWQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-3.0.1.tgz",
+      "integrity": "sha512-OIzpWgtpg0wshdS60Fz6QgXfsYqnWSfQx/9/bmp0eiiKgvtOJa9QmdfFAaGI2BRVoOyiulTMLetSvOAkuTJBPA==",
       "dev": true,
       "dependencies": {
         "@ionic/cli-framework-output": "^2.2.1",
@@ -467,9 +467,9 @@
         "debug": "^4.2.0",
         "env-paths": "^2.2.0",
         "kleur": "^4.1.1",
-        "native-run": "^1.2.1",
+        "native-run": "^1.4.0",
         "open": "^7.1.0",
-        "plist": "^3.0.1",
+        "plist": "^3.0.2",
         "prompts": "^2.3.2",
         "semver": "^7.3.2",
         "tar": "^6.0.5",
@@ -951,7 +951,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -1136,10 +1135,11 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-gU6+Yyd6O0KrCSS/O6j8KKqmRo+/Dcs2fI0+APCpbAWK+nqhwDISpdnSEfGDCLMoAC08XOZCycBRk2K1VGnEcg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-QsxWayZyusnqSZrlCl81R71rA3KqFjVVQSH4E0rGN15F1GdQaFonKlHLyCOLKLig1zzC+DQkLLiUuocexuvdeQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -1259,9 +1259,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "26.0.20",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.20.tgz",
-      "integrity": "sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==",
+      "version": "26.0.23",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
+      "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
       "dev": true,
       "dependencies": {
         "jest-diff": "^26.0.0",
@@ -1284,9 +1284,10 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.14.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
-      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+      "version": "14.17.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
+      "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==",
+      "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -4898,7 +4899,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -5410,7 +5410,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -6369,9 +6368,9 @@
       }
     },
     "node_modules/native-run": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/native-run/-/native-run-1.3.0.tgz",
-      "integrity": "sha512-vV3UiUImFT9QvhfBLVCjDHJTEdNcbeUAwmq3ujy3s8NOOyNq12tQ7jGG3oSOkx7RR+RwgA1deVqBF8/dp/oIYg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/native-run/-/native-run-1.4.0.tgz",
+      "integrity": "sha512-3XJiDxGNi6XCsn8KYDQFSYGDVkKEMg0y55qTMU0feEuPNNU4iztBwW5bE87sfybZsQPsYDJQyYt9CUKDSoJgdQ==",
       "dev": true,
       "dependencies": {
         "@ionic/utils-fs": "^3.0.0",
@@ -6394,9 +6393,9 @@
       }
     },
     "node_modules/native-run/node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
       "dev": true
     },
     "node_modules/natural-compare": {
@@ -6525,10 +6524,11 @@
       }
     },
     "node_modules/np": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/np/-/np-7.4.0.tgz",
-      "integrity": "sha512-woJn5Bodg0/VDyUWx5EHIsi+8QlKSows0AVRBt47PG++cJAVE6jQFXcXDFDBMqY5PueFc4w0SA3gxqPklk6oGg==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/np/-/np-7.5.0.tgz",
+      "integrity": "sha512-CdpgqtO6JpDKJjQ2gueY0jnbz6APWA9wFXSwPv5bXg4seSBibHqQ8JyWxYlS8YRfVbpeDtj582wcAWTlfy5qNA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@samverschueren/stream-to-observable": "^0.3.1",
         "any-observable": "^0.5.1",
@@ -7491,14 +7491,14 @@
       }
     },
     "node_modules/plist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-      "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.2.tgz",
+      "integrity": "sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==",
       "dev": true,
       "dependencies": {
-        "base64-js": "^1.2.3",
+        "base64-js": "^1.5.1",
         "xmlbuilder": "^9.0.7",
-        "xmldom": "0.1.x"
+        "xmldom": "^0.5.0"
       },
       "engines": {
         "node": ">=6"
@@ -7532,9 +7532,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
+      "integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -9105,9 +9105,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
-      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9601,12 +9601,12 @@
       "dev": true
     },
     "node_modules/xmldom": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
       "dev": true,
       "engines": {
-        "node": ">=0.1"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/y18n": {
@@ -10085,9 +10085,9 @@
       "dev": true
     },
     "@capacitor/cli": {
-      "version": "3.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-3.0.0-beta.4.tgz",
-      "integrity": "sha512-gZQZxTvobxRzRdasPmMie0PhvnZ/Phc11jiUYpjyUdhJMxz0CrKpTnQ2bH/yuwfGpGHYKDhXhq4FXZEwevKWWQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-3.0.1.tgz",
+      "integrity": "sha512-OIzpWgtpg0wshdS60Fz6QgXfsYqnWSfQx/9/bmp0eiiKgvtOJa9QmdfFAaGI2BRVoOyiulTMLetSvOAkuTJBPA==",
       "dev": true,
       "requires": {
         "@ionic/cli-framework-output": "^2.2.1",
@@ -10098,9 +10098,9 @@
         "debug": "^4.2.0",
         "env-paths": "^2.2.0",
         "kleur": "^4.1.1",
-        "native-run": "^1.2.1",
+        "native-run": "^1.4.0",
         "open": "^7.1.0",
-        "plist": "^3.0.1",
+        "plist": "^3.0.2",
         "prompts": "^2.3.2",
         "semver": "^7.3.2",
         "tar": "^6.0.5",
@@ -10651,9 +10651,9 @@
       }
     },
     "@stencil/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-gU6+Yyd6O0KrCSS/O6j8KKqmRo+/Dcs2fI0+APCpbAWK+nqhwDISpdnSEfGDCLMoAC08XOZCycBRk2K1VGnEcg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-QsxWayZyusnqSZrlCl81R71rA3KqFjVVQSH4E0rGN15F1GdQaFonKlHLyCOLKLig1zzC+DQkLLiUuocexuvdeQ==",
       "dev": true
     },
     "@szmarczak/http-timer": {
@@ -10764,9 +10764,9 @@
       }
     },
     "@types/jest": {
-      "version": "26.0.20",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.20.tgz",
-      "integrity": "sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==",
+      "version": "26.0.23",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
+      "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
       "dev": true,
       "requires": {
         "jest-diff": "^26.0.0",
@@ -10789,9 +10789,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
-      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+      "version": "14.17.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
+      "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -14842,9 +14842,9 @@
       }
     },
     "native-run": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/native-run/-/native-run-1.3.0.tgz",
-      "integrity": "sha512-vV3UiUImFT9QvhfBLVCjDHJTEdNcbeUAwmq3ujy3s8NOOyNq12tQ7jGG3oSOkx7RR+RwgA1deVqBF8/dp/oIYg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/native-run/-/native-run-1.4.0.tgz",
+      "integrity": "sha512-3XJiDxGNi6XCsn8KYDQFSYGDVkKEMg0y55qTMU0feEuPNNU4iztBwW5bE87sfybZsQPsYDJQyYt9CUKDSoJgdQ==",
       "dev": true,
       "requires": {
         "@ionic/utils-fs": "^3.0.0",
@@ -14861,9 +14861,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
           "dev": true
         }
       }
@@ -14971,9 +14971,9 @@
       "dev": true
     },
     "np": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/np/-/np-7.4.0.tgz",
-      "integrity": "sha512-woJn5Bodg0/VDyUWx5EHIsi+8QlKSows0AVRBt47PG++cJAVE6jQFXcXDFDBMqY5PueFc4w0SA3gxqPklk6oGg==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/np/-/np-7.5.0.tgz",
+      "integrity": "sha512-CdpgqtO6JpDKJjQ2gueY0jnbz6APWA9wFXSwPv5bXg4seSBibHqQ8JyWxYlS8YRfVbpeDtj582wcAWTlfy5qNA==",
       "dev": true,
       "requires": {
         "@samverschueren/stream-to-observable": "^0.3.1",
@@ -15716,14 +15716,14 @@
       }
     },
     "plist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-      "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.2.tgz",
+      "integrity": "sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==",
       "dev": true,
       "requires": {
-        "base64-js": "^1.2.3",
+        "base64-js": "^1.5.1",
         "xmlbuilder": "^9.0.7",
-        "xmldom": "0.1.x"
+        "xmldom": "^0.5.0"
       }
     },
     "posix-character-classes": {
@@ -15745,9 +15745,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
+      "integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==",
       "dev": true
     },
     "pretty-format": {
@@ -17016,9 +17016,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
-      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ=="
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg=="
     },
     "union-value": {
       "version": "1.0.1",
@@ -17416,9 +17416,9 @@
       "dev": true
     },
     "xmldom": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
       "dev": true
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -30,22 +30,22 @@
     "dist/"
   ],
   "dependencies": {
-    "@types/node": "^14.14.31",
+    "@types/node": "^14.17.3",
     "colorette": "^1.2.2",
     "github-slugger": "^1.3.0",
     "minimist": "^1.2.5",
-    "typescript": "^4.2.2"
+    "typescript": "~4.2.4"
   },
   "devDependencies": {
-    "@capacitor/cli": "^3.0.0-beta.3",
-    "@ionic/prettier-config": "^1.0.0",
-    "@stencil/core": "^2.4.0",
+    "@capacitor/cli": "^3.0.1",
+    "@ionic/prettier-config": "^1.0.1",
+    "@stencil/core": "^2.6.0",
     "@types/github-slugger": "^1.3.0",
-    "@types/jest": "^26.0.20",
+    "@types/jest": "^26.0.23",
     "@types/minimist": "^1.2.1",
     "jest": "^26.6.3",
-    "np": "^7.4.0",
-    "prettier": "^2.2.1",
+    "np": "^7.5.0",
+    "prettier": "^2.3.1",
     "rimraf": "^3.0.2"
   },
   "prettier": "@ionic/prettier-config",


### PR DESCRIPTION
update dependencies but fix typescript to ~4.2.x as 4.3.0 breaks tests, so we would need to make code changes to support typescript 4.3.0 in the future.