### PR TITLE
fix: remove final - from addlistener slug

### DIFF
--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -83,6 +83,13 @@ export function formatMethodSignature(m: DocsInterfaceMethod) {
   return `${m.name}(${m.parameters.length > 0 ? '...' : ''})`;
 }
 
+export function formatMethodSignatureForSlug(m: DocsInterfaceMethod) {
+  if (m.name === 'addListener' && m.parameters.length > 0) {
+    return `addListener(${m.parameters[0].type.replace(/\"/g, `'`)})`;
+  }
+  return `${m.name}(${m.parameters.length > 0 ? '...' : ''})`;
+}
+
 function linkToken(data: DocsData, token: string) {
   const t = token.replace(/`/g, '');
   const i = data.interfaces.find(i => {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -15,7 +15,7 @@ import type {
 } from './types';
 import { getTsProgram } from './transpile';
 import GithubSlugger from 'github-slugger';
-import { formatMethodSignature } from './formatting';
+import { formatMethodSignatureForSlug } from './formatting';
 
 /**
  * Given either a tsconfig file path, or exact input files, will
@@ -325,7 +325,7 @@ function getInterfaceMethod(
     slug: '',
   };
 
-  m.slug = slugify(formatMethodSignature(m));
+  m.slug = slugify(formatMethodSignatureForSlug(m));
 
   return m;
 }

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -11,7 +11,7 @@ Below is an index of all the methods available.
 * [`impact(...)`](#impact)
 * [`notification(...)`](#notification)
 * [`vibrate(...)`](#vibrate)
-* [`addListener('vibrate', ...)`](#addlistenervibrate-)
+* [`addListener('vibrate', ...)`](#addlistenervibrate)
 * [`removeAllListeners()`](#removealllisteners)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)

--- a/src/test/docs.json
+++ b/src/test/docs.json
@@ -110,7 +110,7 @@
         "complexTypes": [
           "VibrateListener"
         ],
-        "slug": "addlistenervibrate-"
+        "slug": "addlistenervibrate"
       },
       {
         "name": "removeAllListeners",

--- a/src/test/parse.spec.ts
+++ b/src/test/parse.spec.ts
@@ -90,7 +90,7 @@ describe('parse', () => {
 
     const m3 = api.methods[3];
     expect(m3.name).toBe(`addListener`);
-    expect(m3.slug).toBe(`addlistenervibrate-`);
+    expect(m3.slug).toBe(`addlistenervibrate`);
     expect(m3.docs).toBe(`Add a listener. Callback has VibrateOptions.`);
     expect(m3.signature).toBe(
       `(eventName: 'vibrate', listenerFunc: VibrateListener) => Promise<void>`,


### PR DESCRIPTION
The `docgen-index` links for addListener methods end with `-`, which breaks the links on capacitor docs site.
This PR removes the final `-` so links work fine.