### PR TITLE
feat(): enable extends from jsdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,37 @@ docs can also be linked to and shared.
 - [Example JSON Output](https://github.com/ionic-team/capacitor-docgen/blob/main/src/test/docs.json)
 
 
+## Extension jsdoc
+
+If interface use `extends`, you should add jsdocs for reflect docgen.
+
+for example:
+
+```ts
+/**
+ * @extends addOption
+ */
+export interface HapticsImpactOptions extends addOption {
+  /**
+   * Impact Feedback Style
+   *
+   * The mass of the objects in the collision simulated by a
+   * [`UIImpactFeedbackGenerator`](https://developer.apple.com/documentation/uikit/uiimpactfeedbackstyle) object.
+   * Type is a `HapticsImpactStyle`.
+   *
+   * @default HapticsImpactStyle.Heavy
+   * @since 1.0.0
+   */
+  style: HapticsImpactStyle;
+
+  value: boolean;
+}
+
+export interface addOption {
+  recursive: HapticsImpactOptions;
+}
+```
+
 ## CLI
 
 The easiest way to run `docgen` is to install `@capacitor/docgen` as a dev dependency

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -78,6 +78,13 @@ function collectInterfaces(
   enums: DocsEnum[]
 ) {
   if (i.name !== data.api?.name && !data.interfaces.some((di) => di.name === i.name)) {
+    const tags = i.tags.filter(tag => tag.name === 'extends' && tag.text?.trim()).map(tag => tag.text?.trim());
+    if (tags.length > 0) {
+      const extendsInterfaces = interfaces.filter(i => [...new Set(tags)].includes(i.name)).map(i => i.properties);
+      i.properties = i.properties.concat(extendsInterfaces.flat(1)).filter((elem, index, self) =>  {
+        return self.indexOf(elem) === index;
+      });
+    }
     data.interfaces.push(i);
   }
 

--- a/src/test/fixtures/definitions.ts
+++ b/src/test/fixtures/definitions.ts
@@ -119,7 +119,10 @@ export interface HapticsImpact {
   value: number;
 }
 
-export interface HapticsImpactOptions {
+/**
+ * @extends addOption
+ */
+export interface HapticsImpactOptions extends addOption {
   /**
    * Impact Feedback Style
    *
@@ -133,7 +136,9 @@ export interface HapticsImpactOptions {
   style: HapticsImpactStyle;
 
   value: boolean;
+}
 
+export interface addOption {
   recursive: HapticsImpactOptions;
 }
 


### PR DESCRIPTION
Enable extends from jsdoc. Current, docgen ignore extends.

```ts
/**
 * @extends addOption
 */
export interface HapticsImpactOptions extends addOption {
  style: HapticsImpactStyle;

  value: boolean;
}

export interface addOption {
  recursive: HapticsImpactOptions;
}
```