### PR TITLE
refactor: replace `<a>` with markdown syntax

### DIFF
--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -95,17 +95,17 @@ function linkToken(data: DocsData, token: string) {
     );
   });
   if (i) {
-    return `<a href="#${i.slug}">${token}</a>`;
+    return `[${token}](#${i.slug})`;
   }
 
   const ta = data.typeAliases.find((ta) => ta.name === t);
   if (ta) {
-    return `<a href="#${ta.slug}">${token}</a>`;
+    return `[${token}](#${ta.slug})`;
   }
 
   const e = data.enums.find((e) => e.name === t || e.members.some((m) => e.name + '.' + m.name === t));
   if (e) {
-    return `<a href="#${e.slug}">${token}</a>`;
+    return `[${token}](#${e.slug})`;
   }
 
   return null;

--- a/src/test/formatting.spec.ts
+++ b/src/test/formatting.spec.ts
@@ -41,13 +41,13 @@ describe('formatting', () => {
 
   it('formatDescription w/ backticks', () => {
     const r = formatDescription(d, 'Hey `SomeInterface`!');
-    expect(r).toEqual('Hey <a href="#someinterface">`SomeInterface`</a>!');
+    expect(r).toEqual('Hey [`SomeInterface`](#someinterface)!');
   });
 
   it('formatDescription', () => {
     const r = formatDescription(d, `Hey SomeInterface and SomeInterface.prop and SomeEnum and SomeEnum.Value!`);
     expect(r).toEqual(
-      `Hey <a href=\"#someinterface\">SomeInterface</a> and <a href=\"#someinterface\">SomeInterface.prop</a> and <a href=\"#someenum\">SomeEnum</a> and <a href=\"#someenum\">SomeEnum.Value</a>!`
+      `Hey [SomeInterface](#someinterface) and [SomeInterface.prop](#someinterface) and [SomeEnum](#someenum) and [SomeEnum.Value](#someenum)!`
     );
   });
 
@@ -55,20 +55,20 @@ describe('formatting', () => {
     const r = formatType(d, `Promise<SomeInterface | SomeEnum | Promise<void>>`);
     expect(r.type).toEqual(`Promise<SomeInterface | SomeEnum | Promise<void>>`);
     expect(r.formatted).toEqual(
-      `<code>Promise&lt;<a href="#someinterface">SomeInterface</a> | <a href=\"#someenum\">SomeEnum</a> | Promise&lt;void&gt;&gt;</code>`
+      `<code>Promise&lt;[SomeInterface](#someinterface) | [SomeEnum](#someenum) | Promise&lt;void&gt;&gt;</code>`
     );
   });
 
   it('formatType interface promise', () => {
     const r = formatType(d, `Promise<SomeInterface>`);
     expect(r.type).toEqual(`Promise<SomeInterface>`);
-    expect(r.formatted).toEqual(`<code>Promise&lt;<a href="#someinterface">SomeInterface</a>&gt;</code>`);
+    expect(r.formatted).toEqual(`<code>Promise&lt;[SomeInterface](#someinterface)&gt;</code>`);
   });
 
   it('formatType interface', () => {
     const r = formatType(d, `SomeInterface`);
     expect(r.type).toEqual(`SomeInterface`);
-    expect(r.formatted).toEqual(`<code><a href="#someinterface">SomeInterface</a></code>`);
+    expect(r.formatted).toEqual(`<code>[SomeInterface](#someinterface)</code>`);
   });
 
   it('formatType remove undefined', () => {


### PR DESCRIPTION
Closes #37 