### PR TITLE
feat: Allow to pass the plugin package as param

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ docgen --api HapticsPlugin --output-readme README.md
 | `--output-readme` | `-r`  | Path to the markdown file to update. Note that the file must already exist. **Required** |
 | `--output-json`   | `-j`  | Path to write the raw docs data as a json file.                                          |
 | `--project`       | `-p`  | Path to the project's `tsconfig.json` file, same as the [project](https://www.typescriptlang.org/docs/handbook/compiler-options.html) flag for TypeScript's CLI. By default it'll attempt to find this file. |
+| `--package`       | `-pkg`  | The plugin package name |
 
 
 #### package.json script

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ import fs from 'fs';
  */
 export async function run(config: { cwd: string; args: string[] }) {
   const args = minimist(config.args, {
-    string: ['project', 'api', 'output-json', 'output-readme'],
+    string: ['project', 'api', 'output-json', 'output-readme', 'package'],
     boolean: ['silent'],
     alias: {
       p: 'project',
@@ -19,6 +19,7 @@ export async function run(config: { cwd: string; args: string[] }) {
       j: 'output-json',
       r: 'output-readme',
       s: 'silent',
+      pkg: 'package',
     },
   });
 
@@ -48,6 +49,10 @@ export async function run(config: { cwd: string; args: string[] }) {
     }
     if (args['output-readme']) {
       opts.outputReadmePath = normalizePath(config.cwd, args['output-readme']);
+    }
+
+    if (args['package']) {
+      opts.package = args['package'];
     }
 
     const results = await generate(opts);

--- a/src/output.ts
+++ b/src/output.ts
@@ -217,14 +217,14 @@ function markdownConfig(data: DocsData) {
   if (data.pluginConfigs) {
     data!.pluginConfigs!.forEach((c) => {
       o.push(configInterfaceTable(data, c));
-      o.push(buildExamples(c));
+      o.push(buildExamples(c, data.package));
     });
   }
 
   return o.join('\n');
 }
 
-function buildExamples(c: DocsConfigInterface) {
+function buildExamples(c: DocsConfigInterface, packageName?: string) {
   const o: string[] = [];
   o.push(`### Examples`);
   o.push(``);
@@ -248,7 +248,7 @@ function buildExamples(c: DocsConfigInterface) {
   o.push(`In \`capacitor.config.ts\`:`);
   o.push(``);
   o.push(`\`\`\`ts`);
-  o.push(`/// <reference types="@capacitor/${slugify(c.name.replace(/([a-z])([A-Z])/g, '$1 $2'))}" />`);
+  o.push(`/// <reference types="${packageName ? packageName : "@capacitor/" + slugify(c.name.replace(/([a-z])([A-Z])/g, '$1 $2'))}" />`);
   o.push(``);
   o.push(`import { CapacitorConfig } from '@capacitor/cli';`);
   o.push(``);

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -42,6 +42,7 @@ export function parse(opts: DocsParseOptions) {
 
     const data: DocsData = {
       api: apiInterface,
+      package: opts.package,
       interfaces: [],
       enums: [],
       typeAliases: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export interface DocsData {
   api: DocsInterface | null;
+  package?: string;
   interfaces: DocsInterface[];
   typeAliases: DocsTypeAlias[];
   enums: DocsEnum[];
@@ -93,6 +94,7 @@ export interface DocsTagInfo {
 export interface DocsParseOptions {
   tsconfigPath?: string;
   inputFiles?: string[];
+  package?: string;
 }
 
 export interface DocsGenerateOptions extends DocsParseOptions {


### PR DESCRIPTION
At the moment we hardcode `@capacitor/` and get the plugin name from the types, which works for our plugins but not for 3rd party plugins (see https://github.com/ionic-team/capacitor-docgen/issues/40)

Since we don't have the plugin's package name, I've added a package param that users can pass to the docgen command so it would be used instead of the hardcoded `@capacitor/`, i.e. ` --package @capacitor-community/http`

closes https://github.com/ionic-team/capacitor-docgen/issues/40