### PR TITLE
fix: get plugin package name for config docs

### DIFF
--- a/src/output.ts
+++ b/src/output.ts
@@ -248,7 +248,7 @@ function buildExamples(c: DocsConfigInterface) {
   o.push(`In \`capacitor.config.ts\`:`);
   o.push(``);
   o.push(`\`\`\`ts`);
-  o.push(`/// <reference types="@capacitor/${slugify(c.name.replace(/([a-z])([A-Z])/g, '$1 $2'))}" />`);
+  o.push(`/// <reference types="${process.env.npm_package_name}" />`);
   o.push(``);
   o.push(`import { CapacitorConfig } from '@capacitor/cli';`);
   o.push(``);


### PR DESCRIPTION
Instead of hardcoding the @capacitor/plugin-name, or adding a new parameter for passing the package name as https://github.com/ionic-team/capacitor-docgen/pull/41 did, get the plugin package name from `process.env.npm_package_name` variable.

Closes #40 
Closes #41 