### PR TITLE
Fix dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^14.18.0",
         "colorette": "^2.0.20",
         "github-slugger": "^1.5.0",
         "minimist": "^1.2.8",
@@ -25,6 +24,7 @@
         "@types/babel__traverse": "7.17.1",
         "@types/github-slugger": "^1.3.0",
         "@types/minimist": "^1.2.5",
+        "@types/node": "^14.18.0",
         "jest": "^29.7.0",
         "np": "^7.5.0",
         "prettier": "^3.3.3",
@@ -1623,7 +1623,8 @@
     "node_modules/@types/node": {
       "version": "14.18.63",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",

--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "dist/"
   ],
   "dependencies": {
-    "@types/node": "^14.18.0",
     "colorette": "^2.0.20",
     "github-slugger": "^1.5.0",
     "minimist": "^1.2.8",
     "typescript": "~4.2.4"
   },
   "devDependencies": {
+    "@types/node": "^14.18.0",
     "@capacitor/cli": "^6.1.2",
     "@ionic/prettier-config": "^4.0.0",
     "@stencil/core": "^4.22.1",


### PR DESCRIPTION
Moves `@types/node` to devDependencies as to avoid problems on consuming projects where type clashes might arise.